### PR TITLE
[Feat] #6: Article 도메인 모델 및 DTO 정의

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/App.kt
@@ -1,47 +1,26 @@
 package org.ikseong.devnews
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
-
-import devnews.composeapp.generated.resources.Res
-import devnews.composeapp.generated.resources.compose_multiplatform
 
 @Composable
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
+        Box(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.primaryContainer)
                 .safeContentPadding()
                 .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            contentAlignment = Alignment.Center,
         ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
-            }
+            Text("DevNews")
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/Article.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/Article.kt
@@ -1,0 +1,13 @@
+package org.ikseong.devnews.data.model
+
+import kotlin.time.Instant
+
+data class Article(
+    val id: Long,
+    val title: String,
+    val link: String,
+    val summary: String?,
+    val category: ArticleCategory?,
+    val blogSource: String,
+    val displayDate: Instant,
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleCategory.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleCategory.kt
@@ -1,0 +1,46 @@
+package org.ikseong.devnews.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class ArticleCategory(val displayName: String) {
+    @SerialName("AI")
+    AI("AI"),
+
+    @SerialName("Android")
+    Android("Android"),
+
+    @SerialName("Automation")
+    Automation("Automation"),
+
+    @SerialName("Cross-platform")
+    CrossPlatform("Cross-platform"),
+
+    @SerialName("Data")
+    Data("Data"),
+
+    @SerialName("DevOps")
+    DevOps("DevOps"),
+
+    @SerialName("Hiring")
+    Hiring("Hiring"),
+
+    @SerialName("Infra")
+    Infra("Infra"),
+
+    @SerialName("iOS")
+    IOS("iOS"),
+
+    @SerialName("PM")
+    PM("PM"),
+
+    @SerialName("QA")
+    QA("QA"),
+
+    @SerialName("Server")
+    Server("Server"),
+
+    @SerialName("Web")
+    Web("Web"),
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleDto.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleDto.kt
@@ -1,0 +1,19 @@
+package org.ikseong.devnews.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ArticleDto(
+    val id: Long,
+    val title: String,
+    val link: String,
+    val summary: String? = null,
+    val category: ArticleCategory? = null,
+    @SerialName("blog_source")
+    val blogSource: String,
+    @SerialName("published_at")
+    val publishedAt: String? = null,
+    @SerialName("created_at")
+    val createdAt: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleMapper.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleMapper.kt
@@ -1,0 +1,40 @@
+package org.ikseong.devnews.data.model
+
+import kotlin.time.Instant
+
+fun ArticleDto.toArticle(): Article {
+    val displayDate = parseInstantOrNull(publishedAt)
+        ?: parseInstantOrNull(createdAt)
+        ?: Instant.DISTANT_PAST
+
+    return Article(
+        id = id,
+        title = title,
+        link = link,
+        summary = summary,
+        category = category,
+        blogSource = blogSource,
+        displayDate = displayDate,
+    )
+}
+
+private fun parseInstantOrNull(dateString: String?): Instant? {
+    if (dateString == null) return null
+    return try {
+        Instant.parse(dateString.normalizeTimestamp())
+    } catch (_: Exception) {
+        null
+    }
+}
+
+private fun String.normalizeTimestamp(): String {
+    return this
+        .replace(" ", "T")
+        .let { normalized ->
+            if (normalized.matches(Regex(".*[+-]\\d{2}$"))) {
+                "${normalized}:00"
+            } else {
+                normalized
+            }
+        }
+}


### PR DESCRIPTION
Close #6

## 작업 내용

- ArticleCategory enum 정의 (13종, DB enum과 1:1 매핑, @SerialName으로 Cross-platform/iOS 처리)
- ArticleDto 정의 (kotlinx-serialization, Supabase 응답 직접 매핑)
- Article 도메인 모델 정의 (displayDate: Instant로 published_at/created_at fallback 적용)
- ArticleDto → Article 매핑 확장 함수 및 Supabase 날짜 포맷 정규화 로직 구현
- App.kt에서 삭제된 shared 모듈의 Greeting 참조 제거

## 테스트

- [x] 빌드 확인 (Android)
- [x] 빌드 확인 (iOS)