### PR TITLE
[fix] #6: Instant import 수정 및 타임스탬프 파싱 개선

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/Article.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/Article.kt
@@ -1,6 +1,6 @@
 package org.ikseong.devnews.data.model
 
-import kotlin.time.Instant
+import kotlinx.datetime.Instant
 
 data class Article(
     val id: Long,

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleMapper.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/model/ArticleMapper.kt
@@ -1,6 +1,6 @@
 package org.ikseong.devnews.data.model
 
-import kotlin.time.Instant
+import kotlinx.datetime.Instant
 
 fun ArticleDto.toArticle(): Article {
     val displayDate = parseInstantOrNull(publishedAt)
@@ -31,10 +31,12 @@ private fun String.normalizeTimestamp(): String {
     return this
         .replace(" ", "T")
         .let { normalized ->
-            if (normalized.matches(Regex(".*[+-]\\d{2}$"))) {
-                "${normalized}:00"
-            } else {
-                normalized
+            when {
+                normalized.matches(Regex(".*[+-]\\d{2}:\\d{2}$")) -> normalized
+                normalized.endsWith("Z") -> normalized
+                normalized.matches(Regex(".*[+-]\\d{4}$")) -> normalized.dropLast(2) + ":" + normalized.takeLast(2)
+                normalized.matches(Regex(".*[+-]\\d{2}$")) -> "${normalized}:00"
+                else -> normalized
             }
         }
 }


### PR DESCRIPTION
- kotlin.time.Instant → kotlinx.datetime.Instant로 변경
- normalizeTimestamp()에 +HHMM 형식 오프셋 처리 추가

https://claude.ai/code/session_01K9MBWttxnW7UTGmLvqDofW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp normalization to handle various date format variations, ensuring consistent and reliable date/time display across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->