### PR TITLE
[Feat] #13: Bottom Tab Navigation 구조

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material3)
+            implementation(compose.materialIconsExtended)
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(libs.androidx.lifecycle.viewmodelCompose)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/App.kt
@@ -1,30 +1,12 @@
 package org.ikseong.devnews
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import org.ikseong.devnews.navigation.AppNavigation
 import org.ikseong.devnews.ui.theme.DevNewsTheme
 
 @Composable
 fun App() {
     DevNewsTheme {
-        Box(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background)
-                .safeContentPadding()
-                .fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = "DevNews",
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-        }
+        AppNavigation()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/AppNavigation.kt
@@ -1,0 +1,80 @@
+package org.ikseong.devnews.navigation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import org.ikseong.devnews.ui.screen.favorite.FavoriteScreen
+import org.ikseong.devnews.ui.screen.history.HistoryScreen
+import org.ikseong.devnews.ui.screen.home.HomeScreen
+import org.ikseong.devnews.ui.screen.settings.SettingsScreen
+
+@Composable
+fun AppNavigation() {
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                TopLevelDestination.entries.forEach { destination ->
+                    val selected = currentDestination?.hierarchy?.any {
+                        it.hasRoute(destination.route::class)
+                    } == true
+
+                    NavigationBarItem(
+                        selected = selected,
+                        onClick = {
+                            navController.navigate(destination.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = if (selected) destination.selectedIcon else destination.unselectedIcon,
+                                contentDescription = destination.label,
+                            )
+                        },
+                        label = { Text(destination.label) },
+                    )
+                }
+            }
+        },
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = Route.Home,
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            composable<Route.Home> {
+                HomeScreen()
+            }
+            composable<Route.Favorite> {
+                FavoriteScreen()
+            }
+            composable<Route.History> {
+                HistoryScreen()
+            }
+            composable<Route.Settings> {
+                SettingsScreen()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/Route.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/Route.kt
@@ -1,0 +1,21 @@
+package org.ikseong.devnews.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface Route {
+
+    @Serializable
+    data object Home : Route
+
+    @Serializable
+    data object Favorite : Route
+
+    @Serializable
+    data object History : Route
+
+    @Serializable
+    data object Settings : Route
+
+    @Serializable
+    data class Detail(val articleId: Long, val link: String) : Route
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/TopLevelDestination.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/TopLevelDestination.kt
@@ -1,0 +1,44 @@
+package org.ikseong.devnews.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class TopLevelDestination(
+    val route: Route,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector,
+    val label: String,
+) {
+    HOME(
+        route = Route.Home,
+        selectedIcon = Icons.Filled.Home,
+        unselectedIcon = Icons.Outlined.Home,
+        label = "홈",
+    ),
+    FAVORITE(
+        route = Route.Favorite,
+        selectedIcon = Icons.Filled.Favorite,
+        unselectedIcon = Icons.Outlined.FavoriteBorder,
+        label = "즐겨찾기",
+    ),
+    HISTORY(
+        route = Route.History,
+        selectedIcon = Icons.Filled.History,
+        unselectedIcon = Icons.Outlined.History,
+        label = "읽기이력",
+    ),
+    SETTINGS(
+        route = Route.Settings,
+        selectedIcon = Icons.Filled.Settings,
+        unselectedIcon = Icons.Outlined.Settings,
+        label = "설정",
+    ),
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteScreen.kt
@@ -1,0 +1,18 @@
+package org.ikseong.devnews.ui.screen.favorite
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun FavoriteScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("즐겨찾기")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryScreen.kt
@@ -1,0 +1,18 @@
+package org.ikseong.devnews.ui.screen.history
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HistoryScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("읽기이력")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeScreen.kt
@@ -1,0 +1,18 @@
+package org.ikseong.devnews.ui.screen.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HomeScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("홈")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/settings/SettingsScreen.kt
@@ -1,0 +1,18 @@
+package org.ikseong.devnews.ui.screen.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SettingsScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("설정")
+    }
+}


### PR DESCRIPTION
Close #13

## 작업 내용

- Route sealed interface 정의 (Home, Favorite, History, Settings, Detail)
- TopLevelDestination enum (선택/미선택 아이콘, 라벨)
- Scaffold + NavigationBar + NavHost 구조 구현
- 각 탭 placeholder 화면 생성 (HomeScreen, FavoriteScreen, HistoryScreen, SettingsScreen)
- materialIconsExtended 의존성 추가

## 테스트

- [x] 빌드 확인 (Android)
- [ ] 빌드 확인 (iOS)
- [ ] 탭 전환 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a bottom navigation bar providing quick access to Home, Favorite, History, and Settings sections
  * Navigation items display distinct filled and outlined icons that visually indicate the currently active section
  * Implemented four new dedicated screens, one for each main section, with smooth navigation transitions between them
<!-- end of auto-generated comment: release notes by coderabbit.ai -->