### PR TITLE
[Feat] #17: HomeScreen 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
@@ -2,6 +2,8 @@ package org.ikseong.devnews.di
 
 import org.ikseong.devnews.data.remote.SupabaseProvider
 import org.ikseong.devnews.data.repository.ArticleRepository
+import org.ikseong.devnews.ui.screen.home.HomeViewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val dataModule = module {
@@ -10,4 +12,5 @@ val dataModule = module {
 }
 
 val viewModelModule = module {
+    viewModelOf(::HomeViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/component/CategoryFilterRow.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/component/CategoryFilterRow.kt
@@ -1,0 +1,48 @@
+package org.ikseong.devnews.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.ikseong.devnews.data.model.ArticleCategory
+
+@Composable
+fun CategoryFilterRow(
+    selectedCategory: ArticleCategory?,
+    onCategorySelected: (ArticleCategory?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val categories = listOf(null) + ArticleCategory.entries
+
+    LazyRow(
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(categories) { category ->
+            val selected = selectedCategory == category
+
+            FilterChip(
+                selected = selected,
+                onClick = { onCategorySelected(category) },
+                label = {
+                    Text(
+                        text = category?.displayName ?: "전체",
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/component/SearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/component/SearchBar.kt
@@ -1,0 +1,64 @@
+package org.ikseong.devnews.ui.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        placeholder = {
+            Text(
+                text = "검색어 입력...",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Filled.Search,
+                contentDescription = "검색",
+            )
+        },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Filled.Clear,
+                        contentDescription = "검색어 지우기",
+                    )
+                }
+            }
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(
+            onSearch = { keyboardController?.hide() },
+        ),
+        shape = MaterialTheme.shapes.medium,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeScreen.kt
@@ -1,18 +1,179 @@
 package org.ikseong.devnews.ui.screen.home
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.ikseong.devnews.ui.component.ArticleCard
+import org.ikseong.devnews.ui.component.CategoryFilterRow
+import org.ikseong.devnews.ui.component.SearchBar
+import org.koin.compose.viewmodel.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text("홈")
+fun HomeScreen(
+    onArticleClick: (articleId: Long, link: String) -> Unit = { _, _ -> },
+    viewModel: HomeViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val totalItems = listState.layoutInfo.totalItemsCount
+            lastVisibleItem >= totalItems - 3 && totalItems > 0
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore && !uiState.isSearchActive) {
+            viewModel.loadMore()
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Text(
+                    text = "DevNews",
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+            },
+            actions = {
+                IconButton(onClick = { viewModel.toggleSearch() }) {
+                    Icon(
+                        imageVector = Icons.Filled.Search,
+                        contentDescription = "검색",
+                    )
+                }
+            },
+        )
+
+        if (uiState.isSearchActive) {
+            SearchBar(
+                query = uiState.searchQuery,
+                onQueryChange = viewModel::updateSearchQuery,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        CategoryFilterRow(
+            selectedCategory = uiState.selectedCategory,
+            onCategorySelected = viewModel::selectCategory,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        PullToRefreshBox(
+            isRefreshing = uiState.isLoading && uiState.articles.isNotEmpty(),
+            onRefresh = viewModel::loadArticles,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            when {
+                uiState.isLoading && uiState.articles.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                uiState.error != null && uiState.articles.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = "오류가 발생했습니다",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = viewModel::loadArticles) {
+                                Icon(Icons.Filled.Refresh, contentDescription = null)
+                                Text("재시도")
+                            }
+                        }
+                    }
+                }
+
+                uiState.articles.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = if (uiState.isSearchActive) "검색 결과가 없습니다" else "아티클이 없습니다",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                else -> {
+                    LazyColumn(
+                        state = listState,
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        items(
+                            items = uiState.articles,
+                            key = { it.id },
+                        ) { article ->
+                            ArticleCard(
+                                article = article,
+                                onClick = { onArticleClick(article.id, article.link) },
+                            )
+                        }
+
+                        if (uiState.isLoadingMore) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeUiState.kt
@@ -1,0 +1,15 @@
+package org.ikseong.devnews.ui.screen.home
+
+import org.ikseong.devnews.data.model.Article
+import org.ikseong.devnews.data.model.ArticleCategory
+
+data class HomeUiState(
+    val articles: List<Article> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val error: String? = null,
+    val selectedCategory: ArticleCategory? = null,
+    val searchQuery: String = "",
+    val isSearchActive: Boolean = false,
+    val hasMorePages: Boolean = true,
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/home/HomeViewModel.kt
@@ -1,0 +1,151 @@
+package org.ikseong.devnews.ui.screen.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.ikseong.devnews.data.model.ArticleCategory
+import org.ikseong.devnews.data.repository.ArticleRepository
+
+@OptIn(FlowPreview::class)
+class HomeViewModel(
+    private val articleRepository: ArticleRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    private val searchQueryFlow = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    private var currentPage = 0
+
+    init {
+        loadArticles()
+        observeSearchQuery()
+    }
+
+    fun loadArticles() {
+        currentPage = 0
+        _uiState.update { it.copy(isLoading = true, error = null, hasMorePages = true) }
+
+        viewModelScope.launch {
+            runCatching {
+                fetchArticles(offset = 0)
+            }.onSuccess { articles ->
+                _uiState.update {
+                    it.copy(
+                        articles = articles,
+                        isLoading = false,
+                        hasMorePages = articles.size >= ArticleRepository.DEFAULT_PAGE_SIZE,
+                    )
+                }
+            }.onFailure { e ->
+                _uiState.update {
+                    it.copy(isLoading = false, error = e.message)
+                }
+            }
+        }
+    }
+
+    fun loadMore() {
+        val state = _uiState.value
+        if (state.isLoading || state.isLoadingMore || !state.hasMorePages) return
+
+        currentPage++
+        _uiState.update { it.copy(isLoadingMore = true) }
+
+        viewModelScope.launch {
+            runCatching {
+                fetchArticles(offset = currentPage * ArticleRepository.DEFAULT_PAGE_SIZE)
+            }.onSuccess { articles ->
+                _uiState.update {
+                    it.copy(
+                        articles = it.articles + articles,
+                        isLoadingMore = false,
+                        hasMorePages = articles.size >= ArticleRepository.DEFAULT_PAGE_SIZE,
+                    )
+                }
+            }.onFailure { e ->
+                currentPage--
+                _uiState.update {
+                    it.copy(isLoadingMore = false, error = e.message)
+                }
+            }
+        }
+    }
+
+    fun selectCategory(category: ArticleCategory?) {
+        if (_uiState.value.selectedCategory == category) return
+        _uiState.update { it.copy(selectedCategory = category) }
+        loadArticles()
+    }
+
+    fun updateSearchQuery(query: String) {
+        _uiState.update { it.copy(searchQuery = query) }
+        searchQueryFlow.tryEmit(query)
+    }
+
+    fun toggleSearch() {
+        val isActive = !_uiState.value.isSearchActive
+        _uiState.update {
+            it.copy(
+                isSearchActive = isActive,
+                searchQuery = if (!isActive) "" else it.searchQuery,
+            )
+        }
+        if (!isActive) {
+            loadArticles()
+        }
+    }
+
+    private fun observeSearchQuery() {
+        viewModelScope.launch {
+            searchQueryFlow
+                .debounce(300)
+                .distinctUntilChanged()
+                .collect { query ->
+                    if (query.isBlank()) {
+                        loadArticles()
+                    } else {
+                        searchArticles(query)
+                    }
+                }
+        }
+    }
+
+    private fun searchArticles(query: String) {
+        currentPage = 0
+        _uiState.update { it.copy(isLoading = true, error = null) }
+
+        viewModelScope.launch {
+            runCatching {
+                articleRepository.searchArticles(query)
+            }.onSuccess { articles ->
+                _uiState.update {
+                    it.copy(
+                        articles = articles,
+                        isLoading = false,
+                        hasMorePages = false,
+                    )
+                }
+            }.onFailure { e ->
+                _uiState.update {
+                    it.copy(isLoading = false, error = e.message)
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchArticles(offset: Int) =
+        articleRepository.getArticles(
+            category = _uiState.value.selectedCategory,
+            offset = offset,
+        )
+}


### PR DESCRIPTION
Close #17

## 작업 내용

- HomeViewModel 구현
  - 페이지네이션 (offset 기반, 무한 스크롤)
  - 카테고리 필터링
  - 키워드 검색 (debounce 300ms)
  - Pull to Refresh
- HomeUiState 정의 (articles, isLoading, isLoadingMore, error, selectedCategory, searchQuery)
- CategoryFilterRow 컴포넌트 (전체 + 13개 카테고리 FilterChip 가로 스크롤)
- SearchBar 컴포넌트 (OutlinedTextField, 검색/삭제 아이콘)
- HomeScreen 구현
  - TopAppBar (DevNews 타이틀, 검색 토글)
  - LazyColumn 아티클 리스트
  - Loading / Empty / Error 상태 처리
  - 무한 스크롤 (마지막 3개 아이템 접근 시 다음 페이지 로드)
- Koin viewModelModule에 HomeViewModel 등록

## 테스트

- [x] 빌드 확인 (Android)
- [ ] 빌드 확인 (iOS)
- [ ] 아티클 리스트 로딩 확인
- [ ] 카테고리 필터 동작 확인
- [ ] 검색 동작 확인
- [ ] 무한 스크롤 동작 확인
- [ ] Pull to Refresh 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search functionality to find articles by keyword
  * Added category filter chips to browse articles by topic
  * Enhanced home screen with pull-to-refresh and infinite scroll loading
  * Improved article browsing experience with optimized layout and controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->