### PR TITLE
[Fix] iOS CI 시뮬레이터 destination 수정

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Build iOS App
         run: |
           cd iosApp
-          xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16' build
+          xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'generic/platform=iOS Simulator' build


### PR DESCRIPTION
## 작업 내용

- macos-latest 러너의 Xcode 16.4에서 iPhone 16 시뮬레이터를 찾지 못하는 문제 수정
- `generic/platform=iOS Simulator` destination 사용으로 Xcode 버전에 독립적으로 동작

## 테스트

- [ ] iOS CI 빌드 성공 확인