### PR TITLE
[Feat] #25: Room KMP 로컬 DB 설정

### DIFF
--- a/composeApp/schemas/org.ikseong.devnews.data.local.AppDatabase/1.json
+++ b/composeApp/schemas/org.ikseong.devnews.data.local.AppDatabase/1.json
@@ -1,0 +1,129 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "214f17c6d027b6b07a2bb0bb98060352",
+    "entities": [
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleId` INTEGER NOT NULL, `title` TEXT NOT NULL, `link` TEXT NOT NULL, `summary` TEXT, `category` TEXT, `blogSource` TEXT NOT NULL, `displayDate` INTEGER NOT NULL, `savedAt` INTEGER NOT NULL, PRIMARY KEY(`articleId`))",
+        "fields": [
+          {
+            "fieldPath": "articleId",
+            "columnName": "articleId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blogSource",
+            "columnName": "blogSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayDate",
+            "columnName": "displayDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "articleId"
+          ]
+        }
+      },
+      {
+        "tableName": "read_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleId` INTEGER NOT NULL, `title` TEXT NOT NULL, `link` TEXT NOT NULL, `summary` TEXT, `category` TEXT, `blogSource` TEXT NOT NULL, `displayDate` INTEGER NOT NULL, `readAt` INTEGER NOT NULL, PRIMARY KEY(`articleId`))",
+        "fields": [
+          {
+            "fieldPath": "articleId",
+            "columnName": "articleId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blogSource",
+            "columnName": "blogSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayDate",
+            "columnName": "displayDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "readAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "articleId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '214f17c6d027b6b07a2bb0bb98060352')"
+    ]
+  }
+}

--- a/composeApp/src/androidMain/kotlin/org/ikseong/devnews/data/local/DatabaseFactory.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/ikseong/devnews/data/local/DatabaseFactory.android.kt
@@ -1,0 +1,19 @@
+package org.ikseong.devnews.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+actual class DatabaseFactory(private val context: Context) {
+    actual fun create(): RoomDatabase.Builder<AppDatabase> {
+        val dbFile = context.getDatabasePath(DB_NAME)
+        return Room.databaseBuilder<AppDatabase>(
+            context = context,
+            name = dbFile.absolutePath,
+        )
+    }
+
+    companion object {
+        private const val DB_NAME = "devnews.db"
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/ikseong/devnews/di/PlatformModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/ikseong/devnews/di/PlatformModule.android.kt
@@ -1,7 +1,9 @@
 package org.ikseong.devnews.di
 
+import org.ikseong.devnews.data.local.DatabaseFactory
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val platformModule: Module = module {
+    single { DatabaseFactory(get()) }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/AppDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/AppDatabase.kt
@@ -1,0 +1,23 @@
+package org.ikseong.devnews.data.local
+
+import androidx.room.ConstructedBy
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.RoomDatabaseConstructor
+import org.ikseong.devnews.data.local.dao.FavoriteDao
+import org.ikseong.devnews.data.local.dao.ReadHistoryDao
+import org.ikseong.devnews.data.local.entity.FavoriteEntity
+import org.ikseong.devnews.data.local.entity.ReadHistoryEntity
+
+@Database(
+    entities = [FavoriteEntity::class, ReadHistoryEntity::class],
+    version = 1,
+)
+@ConstructedBy(AppDatabaseConstructor::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun favoriteDao(): FavoriteDao
+    abstract fun readHistoryDao(): ReadHistoryDao
+}
+
+@Suppress("NO_ACTUAL_FOR_EXPECT")
+expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase>

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/DatabaseFactory.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/DatabaseFactory.kt
@@ -1,0 +1,7 @@
+package org.ikseong.devnews.data.local
+
+import androidx.room.RoomDatabase
+
+expect class DatabaseFactory {
+    fun create(): RoomDatabase.Builder<AppDatabase>
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/dao/FavoriteDao.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/dao/FavoriteDao.kt
@@ -1,0 +1,27 @@
+package org.ikseong.devnews.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import org.ikseong.devnews.data.local.entity.FavoriteEntity
+
+@Dao
+interface FavoriteDao {
+
+    @Query("SELECT * FROM favorites ORDER BY savedAt DESC")
+    fun getAll(): Flow<List<FavoriteEntity>>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM favorites WHERE articleId = :articleId)")
+    fun isFavorite(articleId: Long): Flow<Boolean>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: FavoriteEntity)
+
+    @Query("DELETE FROM favorites WHERE articleId = :articleId")
+    suspend fun deleteByArticleId(articleId: Long)
+
+    @Query("DELETE FROM favorites")
+    suspend fun deleteAll()
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/dao/ReadHistoryDao.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/dao/ReadHistoryDao.kt
@@ -1,0 +1,21 @@
+package org.ikseong.devnews.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import org.ikseong.devnews.data.local.entity.ReadHistoryEntity
+
+@Dao
+interface ReadHistoryDao {
+
+    @Query("SELECT * FROM read_history ORDER BY readAt DESC")
+    fun getAll(): Flow<List<ReadHistoryEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ReadHistoryEntity)
+
+    @Query("DELETE FROM read_history")
+    suspend fun deleteAll()
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/entity/FavoriteEntity.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/entity/FavoriteEntity.kt
@@ -1,0 +1,16 @@
+package org.ikseong.devnews.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favorites")
+data class FavoriteEntity(
+    @PrimaryKey val articleId: Long,
+    val title: String,
+    val link: String,
+    val summary: String?,
+    val category: String?,
+    val blogSource: String,
+    val displayDate: Long,
+    val savedAt: Long,
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/entity/ReadHistoryEntity.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/entity/ReadHistoryEntity.kt
@@ -1,0 +1,16 @@
+package org.ikseong.devnews.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "read_history")
+data class ReadHistoryEntity(
+    @PrimaryKey val articleId: Long,
+    val title: String,
+    val link: String,
+    val summary: String?,
+    val category: String?,
+    val blogSource: String,
+    val displayDate: Long,
+    val readAt: Long,
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
@@ -1,5 +1,8 @@
 package org.ikseong.devnews.di
 
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import org.ikseong.devnews.data.local.AppDatabase
+import org.ikseong.devnews.data.local.DatabaseFactory
 import org.ikseong.devnews.data.remote.SupabaseProvider
 import org.ikseong.devnews.data.repository.ArticleRepository
 import org.ikseong.devnews.ui.screen.home.HomeViewModel
@@ -9,6 +12,14 @@ import org.koin.dsl.module
 val dataModule = module {
     single { SupabaseProvider.client }
     single { ArticleRepository(get()) }
+
+    single {
+        get<DatabaseFactory>().create()
+            .setDriver(BundledSQLiteDriver())
+            .build()
+    }
+    single { get<AppDatabase>().favoriteDao() }
+    single { get<AppDatabase>().readHistoryDao() }
 }
 
 val viewModelModule = module {

--- a/composeApp/src/iosMain/kotlin/org/ikseong/devnews/data/local/DatabaseFactory.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/ikseong/devnews/data/local/DatabaseFactory.ios.kt
@@ -1,0 +1,28 @@
+package org.ikseong.devnews.data.local
+
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUserDomainMask
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+actual class DatabaseFactory {
+    actual fun create(): RoomDatabase.Builder<AppDatabase> {
+        val documentDirectory = NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = false,
+            error = null,
+        )
+        val dbFilePath = requireNotNull(documentDirectory?.path) + "/$DB_NAME"
+        return Room.databaseBuilder<AppDatabase>(
+            name = dbFilePath,
+        )
+    }
+
+    companion object {
+        private const val DB_NAME = "devnews.db"
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/ikseong/devnews/di/PlatformModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/ikseong/devnews/di/PlatformModule.ios.kt
@@ -1,7 +1,9 @@
 package org.ikseong.devnews.di
 
+import org.ikseong.devnews.data.local.DatabaseFactory
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val platformModule: Module = module {
+    single { DatabaseFactory() }
 }


### PR DESCRIPTION
Close #25

## 작업 내용

- FavoriteEntity, ReadHistoryEntity 정의 (Article 정보 포함, Supabase 조회 없이 ArticleCard 렌더링 가능)
- FavoriteDao (getAll, isFavorite, insert, deleteByArticleId, deleteAll)
- ReadHistoryDao (getAll, upsert, deleteAll)
- AppDatabase 정의 (@ConstructedBy로 KMP 지원)
- 플랫폼별 DatabaseFactory expect/actual 구현 (Android: getDatabasePath, iOS: NSDocumentDirectory)
- Koin DI에 AppDatabase, FavoriteDao, ReadHistoryDao 등록

## 테스트

- [x] 빌드 확인 (Android)
- [x] 빌드 확인 (iOS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local storage for saving favorite articles
  * Added reading history tracking functionality
  * Implemented cross-platform support for both iOS and Android devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->