### PR TITLE
[Feat] #27: 즐겨찾기 기능 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/entity/EntityMapper.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/local/entity/EntityMapper.kt
@@ -1,0 +1,52 @@
+package org.ikseong.devnews.data.local.entity
+
+import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import org.ikseong.devnews.data.model.Article
+import org.ikseong.devnews.data.model.ArticleCategory
+
+fun Article.toFavoriteEntity(): FavoriteEntity = FavoriteEntity(
+    articleId = id,
+    title = title,
+    link = link,
+    summary = summary,
+    category = category?.name,
+    blogSource = blogSource,
+    displayDate = displayDate.toEpochMilliseconds(),
+    savedAt = Clock.System.now().toEpochMilliseconds(),
+)
+
+fun FavoriteEntity.toArticle(): Article = Article(
+    id = articleId,
+    title = title,
+    link = link,
+    summary = summary,
+    category = category?.let { name ->
+        ArticleCategory.entries.find { it.name == name }
+    },
+    blogSource = blogSource,
+    displayDate = Instant.fromEpochMilliseconds(displayDate),
+)
+
+fun Article.toReadHistoryEntity(): ReadHistoryEntity = ReadHistoryEntity(
+    articleId = id,
+    title = title,
+    link = link,
+    summary = summary,
+    category = category?.name,
+    blogSource = blogSource,
+    displayDate = displayDate.toEpochMilliseconds(),
+    readAt = Clock.System.now().toEpochMilliseconds(),
+)
+
+fun ReadHistoryEntity.toArticle(): Article = Article(
+    id = articleId,
+    title = title,
+    link = link,
+    summary = summary,
+    category = category?.let { name ->
+        ArticleCategory.entries.find { it.name == name }
+    },
+    blogSource = blogSource,
+    displayDate = Instant.fromEpochMilliseconds(displayDate),
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/repository/ArticleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/repository/ArticleRepository.kt
@@ -47,6 +47,17 @@ class ArticleRepository(private val client: SupabaseClient) {
             .map { it.toArticle() }
     }
 
+    suspend fun getArticle(id: Long): Article? {
+        return client.from(TABLE_NAME)
+            .select {
+                filter { eq("id", id) }
+                limit(1)
+            }
+            .decodeList<ArticleDto>()
+            .firstOrNull()
+            ?.toArticle()
+    }
+
     companion object {
         private const val TABLE_NAME = "tech_blog_articles"
         const val DEFAULT_PAGE_SIZE = 20

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/repository/FavoriteRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/repository/FavoriteRepository.kt
@@ -1,0 +1,31 @@
+package org.ikseong.devnews.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.ikseong.devnews.data.local.dao.FavoriteDao
+import org.ikseong.devnews.data.local.entity.toArticle
+import org.ikseong.devnews.data.local.entity.toFavoriteEntity
+import org.ikseong.devnews.data.model.Article
+
+class FavoriteRepository(private val favoriteDao: FavoriteDao) {
+
+    fun getAll(): Flow<List<Article>> =
+        favoriteDao.getAll().map { entities -> entities.map { it.toArticle() } }
+
+    fun isFavorite(articleId: Long): Flow<Boolean> =
+        favoriteDao.isFavorite(articleId)
+
+    suspend fun toggle(article: Article) {
+        val exists = favoriteDao.isFavorite(article.id).first()
+        if (exists) {
+            favoriteDao.deleteByArticleId(article.id)
+        } else {
+            favoriteDao.insert(article.toFavoriteEntity())
+        }
+    }
+
+    suspend fun deleteAll() {
+        favoriteDao.deleteAll()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
@@ -5,6 +5,9 @@ import org.ikseong.devnews.data.local.AppDatabase
 import org.ikseong.devnews.data.local.DatabaseFactory
 import org.ikseong.devnews.data.remote.SupabaseProvider
 import org.ikseong.devnews.data.repository.ArticleRepository
+import org.ikseong.devnews.data.repository.FavoriteRepository
+import org.ikseong.devnews.ui.screen.detail.DetailViewModel
+import org.ikseong.devnews.ui.screen.favorite.FavoriteViewModel
 import org.ikseong.devnews.ui.screen.home.HomeViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -20,8 +23,12 @@ val dataModule = module {
     }
     single { get<AppDatabase>().favoriteDao() }
     single { get<AppDatabase>().readHistoryDao() }
+
+    single { FavoriteRepository(get()) }
 }
 
 val viewModelModule = module {
     viewModelOf(::HomeViewModel)
+    viewModelOf(::FavoriteViewModel)
+    viewModelOf(::DetailViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/AppNavigation.kt
@@ -16,7 +16,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.toRoute
 import org.ikseong.devnews.ui.screen.detail.DetailScreen
 import org.ikseong.devnews.ui.screen.favorite.FavoriteScreen
 import org.ikseong.devnews.ui.screen.history.HistoryScreen
@@ -77,7 +76,11 @@ fun AppNavigation() {
                 )
             }
             composable<Route.Favorite> {
-                FavoriteScreen()
+                FavoriteScreen(
+                    onArticleClick = { articleId, link ->
+                        navController.navigate(Route.Detail(articleId = articleId, link = link))
+                    },
+                )
             }
             composable<Route.History> {
                 HistoryScreen()
@@ -85,10 +88,8 @@ fun AppNavigation() {
             composable<Route.Settings> {
                 SettingsScreen()
             }
-            composable<Route.Detail> { backStackEntry ->
-                val detail = backStackEntry.toRoute<Route.Detail>()
+            composable<Route.Detail> {
                 DetailScreen(
-                    link = detail.link,
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/detail/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/detail/DetailScreen.kt
@@ -4,25 +4,33 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.ikseong.devnews.ui.component.WebView
 import org.ikseong.devnews.util.openUrl
 import org.ikseong.devnews.util.shareUrl
+import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetailScreen(
-    link: String,
     onBack: () -> Unit,
+    viewModel: DetailViewModel = koinViewModel(),
 ) {
+    val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -36,13 +44,20 @@ fun DetailScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { openUrl(link) }) {
+                    IconButton(onClick = { viewModel.toggleFavorite() }) {
+                        Icon(
+                            imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                            contentDescription = if (isFavorite) "즐겨찾기 해제" else "즐겨찾기 추가",
+                            tint = if (isFavorite) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                    IconButton(onClick = { openUrl(viewModel.link) }) {
                         Icon(
                             imageVector = Icons.Filled.OpenInBrowser,
                             contentDescription = "외부 브라우저로 열기",
                         )
                     }
-                    IconButton(onClick = { shareUrl(link) }) {
+                    IconButton(onClick = { shareUrl(viewModel.link) }) {
                         Icon(
                             imageVector = Icons.Filled.Share,
                             contentDescription = "공유",
@@ -53,7 +68,7 @@ fun DetailScreen(
         },
     ) { innerPadding ->
         WebView(
-            url = link,
+            url = viewModel.link,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/detail/DetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/detail/DetailViewModel.kt
@@ -1,0 +1,53 @@
+package org.ikseong.devnews.ui.screen.detail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.ikseong.devnews.data.model.Article
+import org.ikseong.devnews.data.repository.ArticleRepository
+import org.ikseong.devnews.data.repository.FavoriteRepository
+import org.ikseong.devnews.navigation.Route
+
+class DetailViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val articleRepository: ArticleRepository,
+    private val favoriteRepository: FavoriteRepository,
+) : ViewModel() {
+
+    private val detail = savedStateHandle.toRoute<Route.Detail>()
+    val link: String = detail.link
+
+    private val _article = MutableStateFlow<Article?>(null)
+    val article: StateFlow<Article?> = _article.asStateFlow()
+
+    val isFavorite: StateFlow<Boolean> = favoriteRepository.isFavorite(detail.articleId)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = false,
+        )
+
+    init {
+        loadArticle()
+    }
+
+    private fun loadArticle() {
+        viewModelScope.launch {
+            _article.value = articleRepository.getArticle(detail.articleId)
+        }
+    }
+
+    fun toggleFavorite() {
+        val article = _article.value ?: return
+        viewModelScope.launch {
+            favoriteRepository.toggle(article)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteScreen.kt
@@ -1,18 +1,115 @@
 package org.ikseong.devnews.ui.screen.favorite
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.ikseong.devnews.ui.component.ArticleCard
+import org.koin.compose.viewmodel.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FavoriteScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text("즐겨찾기")
+fun FavoriteScreen(
+    onArticleClick: (articleId: Long, link: String) -> Unit,
+    viewModel: FavoriteViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("즐겨찾기 전체 삭제") },
+            text = { Text("모든 즐겨찾기를 삭제하시겠습니까?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteAll()
+                        showDeleteDialog = false
+                    },
+                ) {
+                    Text("삭제")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("취소")
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("즐겨찾기") },
+                actions = {
+                    if (uiState.articles.isNotEmpty()) {
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(
+                                imageVector = Icons.Filled.DeleteSweep,
+                                contentDescription = "전체 삭제",
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        if (uiState.articles.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "즐겨찾기한 아티클이 없습니다",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(
+                    items = uiState.articles,
+                    key = { it.id },
+                ) { article ->
+                    ArticleCard(
+                        article = article,
+                        onClick = { onArticleClick(article.id, article.link) },
+                    )
+                }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteUiState.kt
@@ -1,0 +1,7 @@
+package org.ikseong.devnews.ui.screen.favorite
+
+import org.ikseong.devnews.data.model.Article
+
+data class FavoriteUiState(
+    val articles: List<Article> = emptyList(),
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/favorite/FavoriteViewModel.kt
@@ -1,0 +1,28 @@
+package org.ikseong.devnews.ui.screen.favorite
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.ikseong.devnews.data.repository.FavoriteRepository
+
+class FavoriteViewModel(
+    private val favoriteRepository: FavoriteRepository,
+) : ViewModel() {
+
+    val uiState = favoriteRepository.getAll()
+        .map { FavoriteUiState(articles = it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = FavoriteUiState(),
+        )
+
+    fun deleteAll() {
+        viewModelScope.launch {
+            favoriteRepository.deleteAll()
+        }
+    }
+}


### PR DESCRIPTION
Close #27

## 작업 내용

- EntityMapper 구현 (Article ↔ FavoriteEntity/ReadHistoryEntity 변환)
- FavoriteRepository 구현 (toggle, getAll, isFavorite, deleteAll)
- FavoriteViewModel + FavoriteUiState 구현
- FavoriteScreen UI 구현 (LazyColumn + ArticleCard 재사용, Empty state, 전체 삭제 다이얼로그)
- DetailViewModel 구현 (SavedStateHandle에서 Route 추출, Supabase 단건 조회, 즐겨찾기 토글)
- DetailScreen에 즐겨찾기 아이콘(하트) 추가
- ArticleRepository에 getArticle(id) 메서드 추가
- AppNavigation에서 FavoriteScreen onArticleClick 연결

## 테스트

- [x] 빌드 확인 (Android)
- [x] 빌드 확인 (iOS)