### PR TITLE
[Feat] #29: 읽기이력 기능 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/repository/HistoryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/data/repository/HistoryRepository.kt
@@ -1,0 +1,22 @@
+package org.ikseong.devnews.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.ikseong.devnews.data.local.dao.ReadHistoryDao
+import org.ikseong.devnews.data.local.entity.toArticle
+import org.ikseong.devnews.data.local.entity.toReadHistoryEntity
+import org.ikseong.devnews.data.model.Article
+
+class HistoryRepository(private val readHistoryDao: ReadHistoryDao) {
+
+    fun getAll(): Flow<List<Article>> =
+        readHistoryDao.getAll().map { entities -> entities.map { it.toArticle() } }
+
+    suspend fun record(article: Article) {
+        readHistoryDao.upsert(article.toReadHistoryEntity())
+    }
+
+    suspend fun deleteAll() {
+        readHistoryDao.deleteAll()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/di/AppModule.kt
@@ -6,8 +6,10 @@ import org.ikseong.devnews.data.local.DatabaseFactory
 import org.ikseong.devnews.data.remote.SupabaseProvider
 import org.ikseong.devnews.data.repository.ArticleRepository
 import org.ikseong.devnews.data.repository.FavoriteRepository
+import org.ikseong.devnews.data.repository.HistoryRepository
 import org.ikseong.devnews.ui.screen.detail.DetailViewModel
 import org.ikseong.devnews.ui.screen.favorite.FavoriteViewModel
+import org.ikseong.devnews.ui.screen.history.HistoryViewModel
 import org.ikseong.devnews.ui.screen.home.HomeViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -25,10 +27,12 @@ val dataModule = module {
     single { get<AppDatabase>().readHistoryDao() }
 
     single { FavoriteRepository(get()) }
+    single { HistoryRepository(get()) }
 }
 
 val viewModelModule = module {
     viewModelOf(::HomeViewModel)
     viewModelOf(::FavoriteViewModel)
+    viewModelOf(::HistoryViewModel)
     viewModelOf(::DetailViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/navigation/AppNavigation.kt
@@ -83,7 +83,11 @@ fun AppNavigation() {
                 )
             }
             composable<Route.History> {
-                HistoryScreen()
+                HistoryScreen(
+                    onArticleClick = { articleId, link ->
+                        navController.navigate(Route.Detail(articleId = articleId, link = link))
+                    },
+                )
             }
             composable<Route.Settings> {
                 SettingsScreen()

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/detail/DetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/detail/DetailViewModel.kt
@@ -13,12 +13,14 @@ import kotlinx.coroutines.launch
 import org.ikseong.devnews.data.model.Article
 import org.ikseong.devnews.data.repository.ArticleRepository
 import org.ikseong.devnews.data.repository.FavoriteRepository
+import org.ikseong.devnews.data.repository.HistoryRepository
 import org.ikseong.devnews.navigation.Route
 
 class DetailViewModel(
     savedStateHandle: SavedStateHandle,
     private val articleRepository: ArticleRepository,
     private val favoriteRepository: FavoriteRepository,
+    private val historyRepository: HistoryRepository,
 ) : ViewModel() {
 
     private val detail = savedStateHandle.toRoute<Route.Detail>()
@@ -40,7 +42,11 @@ class DetailViewModel(
 
     private fun loadArticle() {
         viewModelScope.launch {
-            _article.value = articleRepository.getArticle(detail.articleId)
+            val article = articleRepository.getArticle(detail.articleId)
+            _article.value = article
+            if (article != null) {
+                historyRepository.record(article)
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryScreen.kt
@@ -1,18 +1,115 @@
 package org.ikseong.devnews.ui.screen.history
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.ikseong.devnews.ui.component.ArticleCard
+import org.koin.compose.viewmodel.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HistoryScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text("읽기이력")
+fun HistoryScreen(
+    onArticleClick: (articleId: Long, link: String) -> Unit,
+    viewModel: HistoryViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("읽기이력 전체 삭제") },
+            text = { Text("모든 읽기이력을 삭제하시겠습니까?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteAll()
+                        showDeleteDialog = false
+                    },
+                ) {
+                    Text("삭제")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("취소")
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("읽기이력") },
+                actions = {
+                    if (uiState.articles.isNotEmpty()) {
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(
+                                imageVector = Icons.Filled.DeleteSweep,
+                                contentDescription = "전체 삭제",
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        if (uiState.articles.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "읽기이력이 없습니다",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(
+                    items = uiState.articles,
+                    key = { it.id },
+                ) { article ->
+                    ArticleCard(
+                        article = article,
+                        onClick = { onArticleClick(article.id, article.link) },
+                    )
+                }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryUiState.kt
@@ -1,0 +1,7 @@
+package org.ikseong.devnews.ui.screen.history
+
+import org.ikseong.devnews.data.model.Article
+
+data class HistoryUiState(
+    val articles: List<Article> = emptyList(),
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/devnews/ui/screen/history/HistoryViewModel.kt
@@ -1,0 +1,28 @@
+package org.ikseong.devnews.ui.screen.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.ikseong.devnews.data.repository.HistoryRepository
+
+class HistoryViewModel(
+    private val historyRepository: HistoryRepository,
+) : ViewModel() {
+
+    val uiState = historyRepository.getAll()
+        .map { HistoryUiState(articles = it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = HistoryUiState(),
+        )
+
+    fun deleteAll() {
+        viewModelScope.launch {
+            historyRepository.deleteAll()
+        }
+    }
+}


### PR DESCRIPTION
Close #29

## 작업 내용

- HistoryRepository 구현 (record upsert, getAll readAt DESC, deleteAll)
- HistoryViewModel + HistoryUiState 구현
- HistoryScreen UI 구현 (LazyColumn + ArticleCard 재사용, Empty state, 전체 삭제 다이얼로그)
- DetailViewModel에 읽기이력 자동 기록 (Article 로드 완료 후 record 호출)
- AppNavigation에서 HistoryScreen onArticleClick → DetailScreen 연결

## 테스트

- [x] 빌드 확인 (Android)
- [x] 빌드 확인 (iOS)