### PR TITLE
[Fix] 루트 build.gradle.kts google-services 참조 제거

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinx.serialization) apply false
-    alias(libs.plugins.google.services) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.room) apply false
 }


### PR DESCRIPTION
## 작업 내용

- 루트 build.gradle.kts에서 `libs.plugins.google.services` 참조 제거
- CD 빌드 실패 수정 (Unresolved reference: google)