### PR TITLE
[Feat] #83: 블로그 모아보기(BlogListScreen) 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/data/repository/ArticleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/data/repository/ArticleRepository.kt
@@ -11,6 +11,7 @@ import org.ikseong.artech.data.model.ArticleDto
 import org.ikseong.artech.data.model.BlogStats
 import org.ikseong.artech.data.model.CategoryGroup
 import org.ikseong.artech.data.model.toArticle
+import io.github.jan.supabase.postgrest.query.Columns
 
 class ArticleRepository(private val client: SupabaseClient) {
 
@@ -106,7 +107,7 @@ class ArticleRepository(private val client: SupabaseClient) {
 
     suspend fun getCategoriesByBlog(blogSource: String): List<String> {
         val raw = client.from(TABLE_NAME)
-            .select(columns = io.github.jan.supabase.postgrest.query.Columns.list("primary_category")) {
+            .select(columns = Columns.list("primary_category")) {
                 filter { eq("blog_source", blogSource) }
             }
             .decodeList<CategoryResult>()
@@ -118,7 +119,7 @@ class ArticleRepository(private val client: SupabaseClient) {
 
     suspend fun getBlogStats(blogSource: String): BlogStats {
         val allArticles = client.from(TABLE_NAME)
-            .select(columns = io.github.jan.supabase.postgrest.query.Columns.list("published_at", "created_at")) {
+            .select(columns = Columns.list("published_at", "created_at")) {
                 filter { eq("blog_source", blogSource) }
                 order("published_at", Order.ASCENDING)
             }
@@ -132,6 +133,19 @@ class ArticleRepository(private val client: SupabaseClient) {
             latestDate = dates.lastOrNull()?.take(10)?.replace("-", "."),
         )
     }
+
+    suspend fun getAllBlogArticleCounts(): Map<String, Int> {
+        return client.postgrest.rpc("get_blog_article_counts")
+            .decodeList<BlogArticleCountResult>()
+            .associate { it.blogSource to it.count }
+    }
+
+    @Serializable
+    private data class BlogArticleCountResult(
+        @SerialName("blog_source")
+        val blogSource: String,
+        val count: Int,
+    )
 
     @Serializable
     private data class BlogStatDto(

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/di/AppModule.kt
@@ -13,6 +13,7 @@ import org.ikseong.artech.data.repository.HistoryRepository
 import org.ikseong.artech.data.repository.SessionManager
 import org.ikseong.artech.data.repository.SettingsRepository
 import org.ikseong.artech.ui.screen.blog.BlogViewModel
+import org.ikseong.artech.ui.screen.bloglist.BlogListViewModel
 import org.ikseong.artech.ui.screen.detail.DetailViewModel
 import org.ikseong.artech.ui.screen.favorite.FavoriteViewModel
 import org.ikseong.artech.ui.screen.history.HistoryViewModel
@@ -52,5 +53,6 @@ val viewModelModule = module {
     viewModelOf(::HistoryViewModel)
     viewModelOf(::DetailViewModel)
     viewModelOf(::BlogViewModel)
+    viewModelOf(::BlogListViewModel)
     viewModelOf(::SettingsViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/AppNavigation.kt
@@ -21,6 +21,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import org.ikseong.artech.ui.screen.blog.BlogScreen
+import org.ikseong.artech.ui.screen.bloglist.BlogListScreen
 import org.ikseong.artech.ui.screen.detail.DetailScreen
 import org.ikseong.artech.ui.screen.favorite.FavoriteScreen
 import org.ikseong.artech.ui.screen.history.HistoryScreen
@@ -35,6 +36,7 @@ fun AppNavigation() {
 
     val isDetailScreen = currentDestination?.hasRoute(Route.Detail::class) == true
     val isBlogScreen = currentDestination?.hasRoute(Route.Blog::class) == true
+    val isBlogListScreen = currentDestination?.hasRoute(Route.BlogList::class) == true
 
     val navigateToHome: () -> Unit = {
         navController.navigate(Route.Home) {
@@ -48,7 +50,7 @@ fun AppNavigation() {
 
     Scaffold(
         bottomBar = {
-            if (!isDetailScreen && !isBlogScreen) {
+            if (!isDetailScreen && !isBlogScreen && !isBlogListScreen) {
                 val primaryColor = MaterialTheme.colorScheme.primary
 
                 NavigationBar(
@@ -104,6 +106,9 @@ fun AppNavigation() {
                     onBlogClick = { blogSource ->
                         navController.navigate(Route.Blog(blogSource = blogSource))
                     },
+                    onBlogListClick = {
+                        navController.navigate(Route.BlogList)
+                    },
                 )
             }
             composable<Route.Favorite> {
@@ -129,7 +134,11 @@ fun AppNavigation() {
                 )
             }
             composable<Route.Settings> {
-                SettingsScreen()
+                SettingsScreen(
+                    onBlogListClick = {
+                        navController.navigate(Route.BlogList)
+                    },
+                )
             }
             composable<Route.Detail> {
                 DetailScreen(
@@ -137,6 +146,14 @@ fun AppNavigation() {
                     onBlogClick = { blogSource ->
                         navController.navigate(Route.Blog(blogSource = blogSource))
                     },
+                )
+            }
+            composable<Route.BlogList> {
+                BlogListScreen(
+                    onBlogClick = { blogSource ->
+                        navController.navigate(Route.Blog(blogSource = blogSource))
+                    },
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable<Route.Blog> {

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/Route.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/Route.kt
@@ -24,4 +24,7 @@ sealed interface Route {
 
     @Serializable
     data class Blog(val blogSource: String) : Route
+
+    @Serializable
+    data object BlogList : Route
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/bloglist/BlogListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/bloglist/BlogListScreen.kt
@@ -1,0 +1,180 @@
+package org.ikseong.artech.ui.screen.bloglist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import org.ikseong.artech.data.model.BlogMeta
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BlogListScreen(
+    onBlogClick: (String) -> Unit,
+    onBack: () -> Unit,
+    viewModel: BlogListViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("블로그 목록") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "뒤로가기",
+                        )
+                    }
+                },
+                windowInsets = WindowInsets(0, 0, 0, 0),
+            )
+        },
+    ) { innerPadding ->
+        when {
+            uiState.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            uiState.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = uiState.error ?: "오류가 발생했습니다",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = viewModel::loadBlogs) {
+                            Icon(Icons.Filled.Refresh, contentDescription = null)
+                            Text("재시도")
+                        }
+                    }
+                }
+            }
+
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(innerPadding),
+                ) {
+                    items(
+                        items = uiState.blogs,
+                        key = { it.blogSource },
+                    ) { item ->
+                        BlogListRow(
+                            item = item,
+                            onClick = { onBlogClick(item.blogSource) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlogListRow(
+    item: BlogListItem,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BlogFavicon(blogMeta = item.blogMeta)
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.blogMeta.name,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = "${item.articleCount}개 아티클",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Composable
+private fun BlogFavicon(blogMeta: BlogMeta) {
+    if (blogMeta.logoUrl.isNotBlank()) {
+        AsyncImage(
+            model = blogMeta.logoUrl,
+            contentDescription = "${blogMeta.name} 로고",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = blogMeta.name.take(1),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/bloglist/BlogListUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/bloglist/BlogListUiState.kt
@@ -1,0 +1,15 @@
+package org.ikseong.artech.ui.screen.bloglist
+
+import org.ikseong.artech.data.model.BlogMeta
+
+data class BlogListItem(
+    val blogSource: String,
+    val blogMeta: BlogMeta,
+    val articleCount: Int,
+)
+
+data class BlogListUiState(
+    val blogs: List<BlogListItem> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/bloglist/BlogListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/bloglist/BlogListViewModel.kt
@@ -1,0 +1,42 @@
+package org.ikseong.artech.ui.screen.bloglist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.ikseong.artech.data.model.BlogMetaRegistry
+import org.ikseong.artech.data.repository.ArticleRepository
+
+class BlogListViewModel(
+    private val articleRepository: ArticleRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BlogListUiState())
+    val uiState: StateFlow<BlogListUiState> = _uiState.asStateFlow()
+
+    init {
+        loadBlogs()
+    }
+
+    fun loadBlogs() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val counts = articleRepository.getAllBlogArticleCounts()
+                val blogs = counts.map { (source, count) ->
+                    BlogListItem(
+                        blogSource = source,
+                        blogMeta = BlogMetaRegistry.getBlogMeta(source),
+                        articleCount = count,
+                    )
+                }.sortedByDescending { it.articleCount }
+                _uiState.update { it.copy(blogs = blogs, isLoading = false) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoading = false, error = e.message ?: "오류가 발생했습니다") }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -25,6 +26,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -68,6 +70,7 @@ import kotlin.time.ExperimentalTime
 fun HomeScreen(
     onArticleClick: (articleId: Long, link: String) -> Unit = { _, _ -> },
     onBlogClick: (String) -> Unit = {},
+    onBlogListClick: () -> Unit = {},
     viewModel: HomeViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -187,6 +190,14 @@ fun HomeScreen(
                     text = "Artech",
                     style = MaterialTheme.typography.headlineSmall,
                 )
+            },
+            actions = {
+                IconButton(onClick = onBlogListClick) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.List,
+                        contentDescription = "블로그 목록",
+                    )
+                }
             },
             windowInsets = WindowInsets(0, 0, 0, 0),
         )

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeleteSweep
@@ -54,6 +55,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
+    onBlogListClick: () -> Unit = {},
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -113,6 +115,20 @@ fun SettingsScreen(
                 onCheckedChange = { checked ->
                     viewModel.setThemeMode(if (checked) ThemeMode.DARK else ThemeMode.LIGHT)
                 },
+            )
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+            )
+
+            SettingsSectionHeader(title = "탐색")
+            SettingsItem(
+                icon = Icons.AutoMirrored.Filled.List,
+                iconBackgroundColor = MaterialTheme.colorScheme.primaryContainer,
+                iconTint = MaterialTheme.colorScheme.primary,
+                title = "블로그 목록",
+                description = "수집 중인 기술 블로그 보기",
+                onClick = onBlogListClick,
             )
             HorizontalDivider(
                 modifier = Modifier.padding(horizontal = 16.dp),


### PR DESCRIPTION
Close #83

## 작업 내용

- BlogListScreen 신규 생성 (favicon + 이름 + 아티클 수 + chevron)
- BlogListViewModel, BlogListUiState 추가
- Supabase RPC(`get_blog_article_counts`)로 블로그별 아티클 수 서버사이드 집계
- HomeScreen TopBar에 블로그 목록 진입 아이콘 추가
- SettingsScreen에 "탐색" 섹션 + 블로그 목록 메뉴 추가
- Route.BlogList 추가 및 바텀탭 숨김 처리
- ArticleRepository 내 Columns import 정리

## 테스트

- [ ] 빌드 확인 (Android)
- [ ] 빌드 확인 (iOS)
- [ ] HomeScreen TopBar 아이콘 → BlogListScreen 진입
- [ ] SettingsScreen 블로그 목록 → BlogListScreen 진입
- [ ] 블로그 행 클릭 → BlogScreen 이동
- [ ] 뒤로가기 → 이전 화면 복귀
- [ ] 바텀 탭 숨김 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 블로그 목록 화면 추가: 구독 중인 모든 블로그를 한 곳에서 조회 가능
- 홈 화면과 설정에 블로그 목록 네비게이션 메뉴 추가
- 각 블로그의 기사 수 표시
- 블로그 파비콘 또는 초기 문자로 블로그 식별 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->