### PR TITLE
[Feat] 홈 추천 섹션 갱신 기능 추가

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/data/repository/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/data/repository/SettingsRepository.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.ikseong.artech.data.model.ThemeMode
 
 class SettingsRepository(
@@ -66,11 +68,45 @@ class SettingsRepository(
         dataStore.edit { it[SKIPPED_OPTIONAL_VERSION_KEY] = version }
     }
 
+    suspend fun getRecommendRefreshRemaining(): Int {
+        val prefs = dataStore.data.first()
+        val savedDate = prefs[RECOMMEND_REFRESH_DATE_KEY]
+        return if (savedDate == todayDateString()) {
+            MAX_RECOMMEND_REFRESHES - (prefs[RECOMMEND_REFRESH_COUNT_KEY] ?: 0)
+        } else {
+            MAX_RECOMMEND_REFRESHES
+        }
+    }
+
+    suspend fun useRecommendRefresh(): Int {
+        val today = todayDateString()
+        val prefs = dataStore.data.first()
+        val savedDate = prefs[RECOMMEND_REFRESH_DATE_KEY]
+        val currentCount = if (savedDate == today) {
+            prefs[RECOMMEND_REFRESH_COUNT_KEY] ?: 0
+        } else {
+            0
+        }
+        val newCount = currentCount + 1
+        dataStore.edit {
+            it[RECOMMEND_REFRESH_DATE_KEY] = today
+            it[RECOMMEND_REFRESH_COUNT_KEY] = newCount
+        }
+        return MAX_RECOMMEND_REFRESHES - newCount
+    }
+
+    private fun todayDateString(): String =
+        Instant.fromEpochMilliseconds(kotlin.time.Clock.System.now().toEpochMilliseconds())
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date.toString()
+
     companion object {
+        const val MAX_RECOMMEND_REFRESHES = 5
         private val THEME_MODE_KEY = stringPreferencesKey("theme_mode")
         private val LAST_VISIT_TIME_KEY = longPreferencesKey("last_visit_time")
         private val SCROLL_POSITION_KEY = intPreferencesKey("scroll_position")
         private val SCROLL_OFFSET_KEY = intPreferencesKey("scroll_offset")
         private val SKIPPED_OPTIONAL_VERSION_KEY = stringPreferencesKey("skipped_optional_version")
+        private val RECOMMEND_REFRESH_DATE_KEY = stringPreferencesKey("recommend_refresh_date")
+        private val RECOMMEND_REFRESH_COUNT_KEY = intPreferencesKey("recommend_refresh_count")
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -56,6 +57,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
+import org.ikseong.artech.data.repository.SettingsRepository
 import org.ikseong.artech.ui.component.ArticleCard
 import org.ikseong.artech.ui.component.CategoryFilterRow
 import org.ikseong.artech.ui.component.RecommendedArticleCard
@@ -268,12 +270,46 @@ fun HomeScreen(
                     ) {
                         if (uiState.recommendedArticles.isNotEmpty() && uiState.selectedCategory == null) {
                             item(key = "recommended_header") {
-                                Text(
-                                    text = "오늘의 추천",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = MaterialTheme.colorScheme.onBackground,
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                                )
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = "오늘의 추천",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    val remaining = uiState.recommendRefreshRemaining
+                                    val enabled = remaining > 0
+                                    Text(
+                                        text = "$remaining/${SettingsRepository.MAX_RECOMMEND_REFRESHES}",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = if (enabled) {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                                        },
+                                    )
+                                    IconButton(
+                                        onClick = viewModel::refreshRecommendations,
+                                        enabled = enabled,
+                                        modifier = Modifier.size(36.dp),
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.Refresh,
+                                            contentDescription = "추천 갱신",
+                                            tint = if (enabled) {
+                                                MaterialTheme.colorScheme.primary
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                                            },
+                                            modifier = Modifier.size(20.dp),
+                                        )
+                                    }
+                                }
                             }
 
                             item(key = "recommended_row") {

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeUiState.kt
@@ -2,10 +2,12 @@ package org.ikseong.artech.ui.screen.home
 
 import kotlinx.datetime.Instant
 import org.ikseong.artech.data.model.Article
+import org.ikseong.artech.data.repository.SettingsRepository
 
 data class HomeUiState(
     val articles: List<Article> = emptyList(),
     val recommendedArticles: List<Article> = emptyList(),
+    val recommendRefreshRemaining: Int = SettingsRepository.MAX_RECOMMEND_REFRESHES,
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
     val error: String? = null,

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.ikseong.artech.data.model.Article
 import org.ikseong.artech.data.repository.ArticleRepository
 import org.ikseong.artech.data.repository.HistoryRepository
 import org.ikseong.artech.data.repository.SettingsRepository
@@ -34,7 +35,10 @@ class HomeViewModel(
     init {
         viewModelScope.launch {
             val lastVisit = settingsRepository.lastVisitTime.first()
-            _uiState.update { it.copy(lastVisitTime = lastVisit) }
+            val refreshRemaining = settingsRepository.getRecommendRefreshRemaining()
+            _uiState.update {
+                it.copy(lastVisitTime = lastVisit, recommendRefreshRemaining = refreshRemaining)
+            }
             settingsRepository.updateLastVisitTime()
             launch { loadCategories() }
             launch {
@@ -65,11 +69,7 @@ class HomeViewModel(
         loadJob = viewModelScope.launch {
             try {
                 val articles = fetchArticles(offset = 0)
-                val recommended = if (articles.size >= 5) {
-                    articles.shuffled().take(5)
-                } else {
-                    articles.shuffled()
-                }
+                val recommended = pickRecommendations(articles)
                 _uiState.update {
                     it.copy(
                         articles = articles,
@@ -120,6 +120,27 @@ class HomeViewModel(
         _uiState.update { it.copy(showUnreadOnly = !it.showUnreadOnly) }
     }
 
+    fun refreshRecommendations() {
+        if (_uiState.value.recommendRefreshRemaining <= 0) return
+        val articles = _uiState.value.articles
+        if (articles.isEmpty()) return
+
+        viewModelScope.launch {
+            val remaining = settingsRepository.useRecommendRefresh()
+            val recommended = if (articles.size >= 5) {
+                articles.shuffled().take(5)
+            } else {
+                articles.shuffled()
+            }
+            _uiState.update {
+                it.copy(
+                    recommendedArticles = recommended,
+                    recommendRefreshRemaining = remaining,
+                )
+            }
+        }
+    }
+
     fun selectCategory(category: String?) {
         if (_uiState.value.selectedCategory == category) return
         _uiState.update { it.copy(selectedCategory = category) }
@@ -142,9 +163,16 @@ class HomeViewModel(
     suspend fun getSavedScrollPosition(): Pair<Int, Int> =
         settingsRepository.getScrollPosition()
 
+    private fun pickRecommendations(articles: List<Article>): List<Article> =
+        if (articles.size >= RECOMMEND_COUNT) articles.shuffled().take(RECOMMEND_COUNT) else articles.shuffled()
+
     private suspend fun fetchArticles(offset: Int) =
         articleRepository.getArticles(
             category = _uiState.value.selectedCategory,
             offset = offset,
         )
+
+    companion object {
+        private const val RECOMMEND_COUNT = 5
+    }
 }


### PR DESCRIPTION
## 작업 내용

- 오늘의 추천 헤더에 갱신 버튼 + 남은 횟수(N/5) 표시
- 하루 5회 갱신 제한 (DataStore에 날짜별 횟수 저장, 날짜 변경 시 자동 리셋)
- 횟수 소진 시 버튼 비활성화
- 셔플 로직 중복 제거 및 매직 넘버 상수화

## 테스트

- [ ] 빌드 확인 (Android)
- [ ] 빌드 확인 (iOS)
- [ ] 갱신 버튼 클릭 시 추천 목록 변경 확인
- [ ] 5회 사용 후 비활성화 확인
- [ ] 앱 재시작 후 횟수 유지 확인
- [ ] 날짜 변경 후 횟수 리셋 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 추천 글 일일 새로고침 횟수 제한(최대 5회) 기능 추가
  * 홈 화면에 남은 새로고침 횟수를 표시하는 카운터 추가
  * 새로고침 버튼을 통해 추천 글 업데이트 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->