### PR TITLE
[Feat] #93: 설정 화면에 문의하기 기능 추가

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/AppNavigation.kt
@@ -28,6 +28,7 @@ import org.ikseong.artech.ui.screen.detail.DetailScreen
 import org.ikseong.artech.ui.screen.favorite.FavoriteScreen
 import org.ikseong.artech.ui.screen.history.HistoryScreen
 import org.ikseong.artech.ui.screen.home.HomeScreen
+import org.ikseong.artech.ui.screen.contact.ContactScreen
 import org.ikseong.artech.ui.screen.settings.SettingsScreen
 
 @Composable
@@ -39,6 +40,7 @@ fun AppNavigation() {
     val isDetailScreen = currentDestination?.hasRoute(Route.Detail::class) == true
     val isBlogScreen = currentDestination?.hasRoute(Route.Blog::class) == true
     val isBlogListScreen = currentDestination?.hasRoute(Route.BlogList::class) == true
+    val isContactScreen = currentDestination?.hasRoute(Route.Contact::class) == true
 
     val navigateToHome: () -> Unit = {
         navController.navigate(Route.Home) {
@@ -52,7 +54,7 @@ fun AppNavigation() {
 
     Scaffold(
         bottomBar = {
-            if (!isDetailScreen && !isBlogScreen && !isBlogListScreen) {
+            if (!isDetailScreen && !isBlogScreen && !isBlogListScreen && !isContactScreen) {
                 val primaryColor = MaterialTheme.colorScheme.primary
 
                 Column {
@@ -146,6 +148,14 @@ fun AppNavigation() {
                     onBlogListClick = {
                         navController.navigate(Route.BlogList)
                     },
+                    onContactClick = {
+                        navController.navigate(Route.Contact)
+                    },
+                )
+            }
+            composable<Route.Contact> {
+                ContactScreen(
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable<Route.Detail> {

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/Route.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/Route.kt
@@ -27,4 +27,7 @@ sealed interface Route {
 
     @Serializable
     data object BlogList : Route
+
+    @Serializable
+    data object Contact : Route
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/contact/ContactScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/contact/ContactScreen.kt
@@ -1,0 +1,81 @@
+package org.ikseong.artech.ui.screen.contact
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import org.ikseong.artech.BuildKonfig
+import org.ikseong.artech.ui.component.ScrollDirection
+import org.ikseong.artech.ui.component.WebView
+
+private const val CONTACT_FORM_URL = "https://easy-contact-lemon.vercel.app/f/oap4r"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactScreen(
+    onBack: () -> Unit,
+) {
+    var isHeaderVisible by remember { mutableStateOf(true) }
+    val url = remember { "$CONTACT_FORM_URL?app_version=${BuildKonfig.APP_VERSION}" }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        topBar = {
+            AnimatedVisibility(
+                visible = isHeaderVisible,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                TopAppBar(
+                    title = { Text("문의하기") },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "뒤로가기",
+                            )
+                        }
+                    },
+                    windowInsets = WindowInsets(0, 0, 0, 0),
+                )
+            }
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            WebView(
+                url = url,
+                modifier = Modifier.fillMaxSize(),
+                onScrollDirectionChanged = { direction ->
+                    when (direction) {
+                        ScrollDirection.DOWN -> isHeaderVisible = false
+                        ScrollDirection.UP -> isHeaderVisible = true
+                        ScrollDirection.NONE -> {}
+                    }
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -56,6 +57,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun SettingsScreen(
     onBlogListClick: () -> Unit = {},
+    onContactClick: () -> Unit = {},
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -160,6 +162,14 @@ fun SettingsScreen(
             )
 
             SettingsSectionHeader(title = "앱 정보")
+            SettingsItem(
+                icon = Icons.Filled.Email,
+                iconBackgroundColor = MaterialTheme.colorScheme.primaryContainer,
+                iconTint = MaterialTheme.colorScheme.primary,
+                title = "문의하기",
+                description = "버그 제보 및 의견 보내기",
+                onClick = onContactClick,
+            )
             SettingsInfoItem(
                 icon = Icons.Filled.Info,
                 iconBackgroundColor = MaterialTheme.colorScheme.surfaceVariant,


### PR DESCRIPTION
Close #93

## 작업 내용

- Route.Contact 추가
- ContactScreen 구현 (EasyContact 웹 폼을 WebView로 표시, app_version 쿼리 파라미터 전달)
- SettingsScreen 앱 정보 섹션에 "문의하기" 항목 추가
- AppNavigation에 Contact 화면 연결 및 바텀바 숨김 처리

## 테스트

- [x] 빌드 확인 (Android)
- [x] 빌드 확인 (iOS)
- [ ] 설정 > 문의하기 탭 시 WebView 문의 페이지 정상 로드 확인
- [ ] 뒤로가기 시 설정 화면 복귀 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 설정에서 버그 보고 및 의견을 보낼 수 있는 새로운 문의하기 옵션 추가
  * 앱 내 웹뷰 기반 문의 폼으로 사용자가 직접 피드백 제출 가능
  * 스크롤 방향에 따라 헤더가 자동으로 표시/숨김되는 인터랙티브 UI 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->