### PR TITLE
feat: add Firebase analytics events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ plugins {
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.room) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -15,6 +15,10 @@ plugins {
     alias(libs.plugins.buildkonfig)
 }
 
+if (project.file("google-services.json").exists()) {
+    apply(plugin = "com.google.gms.google-services")
+}
+
 kotlin {
     androidTarget {
         compilerOptions {
@@ -37,6 +41,8 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.ktor.client.okhttp)
             implementation(libs.koin.android)
+            implementation(project.dependencies.platform(libs.firebase.bom))
+            implementation(libs.firebase.analytics)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -158,6 +164,7 @@ buildkonfig {
         buildConfigField(STRING, "SUPABASE_KEY", System.getenv("SUPABASE_KEY") ?: properties.getProperty("supabase.key", ""))
         buildConfigField(STRING, "APP_VERSION", android.defaultConfig.versionName!!)
         buildConfigField(STRING, "APP_PLATFORM", "android")
+        buildConfigField(STRING, "FIREBASE_ANALYTICS_ENABLED", project.file("google-services.json").exists().toString())
     }
 
     targetConfigs {

--- a/composeApp/src/androidMain/kotlin/org/ikseong/artech/analytics/FirebaseAnalyticsTracker.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/ikseong/artech/analytics/FirebaseAnalyticsTracker.android.kt
@@ -1,0 +1,19 @@
+package org.ikseong.artech.analytics
+
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+
+class FirebaseAnalyticsTracker(
+    private val firebaseAnalytics: FirebaseAnalytics,
+) : AnalyticsTracker {
+    override fun logEvent(event: AnalyticsEvent) {
+        firebaseAnalytics.logEvent(event.name, event.parameters.toBundle())
+    }
+}
+
+private fun Map<String, String>.toBundle(): Bundle =
+    Bundle().also { bundle ->
+        forEach { (key, value) ->
+            bundle.putString(key, value)
+        }
+    }

--- a/composeApp/src/androidMain/kotlin/org/ikseong/artech/di/PlatformModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/ikseong/artech/di/PlatformModule.android.kt
@@ -1,5 +1,10 @@
 package org.ikseong.artech.di
 
+import com.google.firebase.analytics.FirebaseAnalytics
+import org.ikseong.artech.BuildKonfig
+import org.ikseong.artech.analytics.AnalyticsTracker
+import org.ikseong.artech.analytics.FirebaseAnalyticsTracker
+import org.ikseong.artech.analytics.NoOpAnalyticsTracker
 import org.ikseong.artech.data.local.DataStoreFactory
 import org.ikseong.artech.data.local.DatabaseFactory
 import org.koin.core.module.Module
@@ -8,4 +13,12 @@ import org.koin.dsl.module
 actual val platformModule: Module = module {
     single { DatabaseFactory(get()) }
     single { DataStoreFactory(get()) }
+    single { FirebaseAnalytics.getInstance(get()) }
+    single<AnalyticsTracker> {
+        if (BuildKonfig.FIREBASE_ANALYTICS_ENABLED.toBoolean()) {
+            FirebaseAnalyticsTracker(get())
+        } else {
+            NoOpAnalyticsTracker
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/analytics/AnalyticsEvent.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/analytics/AnalyticsEvent.kt
@@ -1,0 +1,99 @@
+package org.ikseong.artech.analytics
+
+data class AnalyticsEvent(
+    val name: String,
+    val parameters: Map<String, String> = emptyMap(),
+)
+
+interface AnalyticsTracker {
+    fun logEvent(event: AnalyticsEvent)
+}
+
+object NoOpAnalyticsTracker : AnalyticsTracker {
+    override fun logEvent(event: AnalyticsEvent) = Unit
+}
+
+object AnalyticsEvents {
+    fun screenView(screenName: String): AnalyticsEvent =
+        event(
+            name = "screen_view",
+            "screen_name" to screenName,
+        )
+
+    fun articleOpen(
+        articleId: Long,
+        source: String,
+        category: String? = null,
+        blogSource: String? = null,
+    ): AnalyticsEvent =
+        event(
+            name = "article_open",
+            "article_id" to articleId,
+            "source" to source,
+            "category" to category,
+            "blog_source" to blogSource,
+        )
+
+    fun categorySelect(
+        source: String,
+        category: String?,
+    ): AnalyticsEvent =
+        event(
+            name = "category_select",
+            "source" to source,
+            "category" to (category ?: "all"),
+        )
+
+    fun blogOpen(
+        source: String,
+        blogSource: String,
+    ): AnalyticsEvent =
+        event(
+            name = "blog_open",
+            "source" to source,
+            "blog_source" to blogSource,
+        )
+
+    fun latestFeedOpen(source: String): AnalyticsEvent =
+        event(
+            name = "latest_feed_open",
+            "source" to source,
+        )
+
+    fun recommendationRefresh(source: String): AnalyticsEvent =
+        event(
+            name = "recommendation_refresh",
+            "source" to source,
+        )
+
+    fun unreadFilterToggle(
+        source: String,
+        enabled: Boolean,
+    ): AnalyticsEvent =
+        event(
+            name = "unread_filter_toggle",
+            "source" to source,
+            "enabled" to enabled,
+        )
+
+    fun tabSelect(destination: String): AnalyticsEvent =
+        event(
+            name = "tab_select",
+            "destination" to destination,
+        )
+
+    private fun event(
+        name: String,
+        vararg parameters: Pair<String, Any?>,
+    ): AnalyticsEvent =
+        AnalyticsEvent(
+            name = name,
+            parameters = parameters
+                .mapNotNull { (key, value) ->
+                    value?.toString()
+                        ?.takeIf(String::isNotBlank)
+                        ?.let { key to it }
+                }
+                .toMap(),
+        )
+}

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/navigation/AppNavigation.kt
@@ -13,8 +13,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -22,6 +24,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import org.ikseong.artech.analytics.AnalyticsEvents
+import org.ikseong.artech.analytics.AnalyticsTracker
 import org.ikseong.artech.ui.screen.blog.BlogScreen
 import org.ikseong.artech.ui.screen.bloglist.BlogListScreen
 import org.ikseong.artech.ui.screen.detail.DetailScreen
@@ -31,12 +35,22 @@ import org.ikseong.artech.ui.screen.home.HomeScreen
 import org.ikseong.artech.ui.screen.contact.ContactScreen
 import org.ikseong.artech.ui.screen.latest.LatestFeedScreen
 import org.ikseong.artech.ui.screen.settings.SettingsScreen
+import org.koin.compose.koinInject
 
 @Composable
-fun AppNavigation() {
+fun AppNavigation(
+    analyticsTracker: AnalyticsTracker = koinInject(),
+) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
+    val currentScreenName = currentDestination.analyticsScreenName()
+
+    LaunchedEffect(currentScreenName) {
+        currentScreenName?.let { screenName ->
+            analyticsTracker.logEvent(AnalyticsEvents.screenView(screenName))
+        }
+    }
 
     val isDetailScreen = currentDestination?.hasRoute(Route.Detail::class) == true
     val isBlogScreen = currentDestination?.hasRoute(Route.Blog::class) == true
@@ -76,6 +90,7 @@ fun AppNavigation() {
                         NavigationBarItem(
                             selected = selected,
                             onClick = {
+                                analyticsTracker.logEvent(AnalyticsEvents.tabSelect(destination.analyticsName))
                                 navController.navigate(destination.route) {
                                     popUpTo(navController.graph.findStartDestination().id) {
                                         saveState = true
@@ -122,9 +137,16 @@ fun AppNavigation() {
                         navController.navigate(Route.BlogList)
                     },
                     onLatestFeedClick = {
+                        analyticsTracker.logEvent(AnalyticsEvents.latestFeedOpen(source = "home"))
                         navController.navigate(Route.LatestFeed())
                     },
                     onTopicClick = { category ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.categorySelect(
+                                source = "home_topic_hub",
+                                category = category,
+                            ),
+                        )
                         navController.navigate(Route.LatestFeed(initialCategory = category))
                     },
                 )
@@ -143,9 +165,21 @@ fun AppNavigation() {
             composable<Route.Favorite> {
                 FavoriteScreen(
                     onArticleClick = { articleId, link ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.articleOpen(
+                                articleId = articleId,
+                                source = "favorite",
+                            ),
+                        )
                         navController.navigate(Route.Detail(articleId = articleId, link = link))
                     },
                     onBlogClick = { blogSource ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.blogOpen(
+                                source = "favorite",
+                                blogSource = blogSource,
+                            ),
+                        )
                         navController.navigate(Route.Blog(blogSource = blogSource))
                     },
                     onNavigateToHome = navigateToHome,
@@ -154,9 +188,21 @@ fun AppNavigation() {
             composable<Route.History> {
                 HistoryScreen(
                     onArticleClick = { articleId, link ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.articleOpen(
+                                articleId = articleId,
+                                source = "history",
+                            ),
+                        )
                         navController.navigate(Route.Detail(articleId = articleId, link = link))
                     },
                     onBlogClick = { blogSource ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.blogOpen(
+                                source = "history",
+                                blogSource = blogSource,
+                            ),
+                        )
                         navController.navigate(Route.Blog(blogSource = blogSource))
                     },
                     onNavigateToHome = navigateToHome,
@@ -181,6 +227,12 @@ fun AppNavigation() {
                 DetailScreen(
                     onBack = { navController.popBackStack() },
                     onBlogClick = { blogSource ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.blogOpen(
+                                source = "detail",
+                                blogSource = blogSource,
+                            ),
+                        )
                         navController.navigate(Route.Blog(blogSource = blogSource))
                     },
                 )
@@ -188,6 +240,12 @@ fun AppNavigation() {
             composable<Route.BlogList> {
                 BlogListScreen(
                     onBlogClick = { blogSource ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.blogOpen(
+                                source = "blog_list",
+                                blogSource = blogSource,
+                            ),
+                        )
                         navController.navigate(Route.Blog(blogSource = blogSource))
                     },
                     onBack = { navController.popBackStack() },
@@ -196,6 +254,12 @@ fun AppNavigation() {
             composable<Route.Blog> {
                 BlogScreen(
                     onArticleClick = { articleId, link ->
+                        analyticsTracker.logEvent(
+                            AnalyticsEvents.articleOpen(
+                                articleId = articleId,
+                                source = "blog",
+                            ),
+                        )
                         navController.navigate(Route.Detail(articleId = articleId, link = link))
                     },
                     onBack = { navController.popBackStack() },
@@ -204,3 +268,26 @@ fun AppNavigation() {
         }
     }
 }
+
+private val TopLevelDestination.analyticsName: String
+    get() = when (this) {
+        TopLevelDestination.HOME -> "home"
+        TopLevelDestination.FAVORITE -> "favorite"
+        TopLevelDestination.HISTORY -> "history"
+        TopLevelDestination.SETTINGS -> "settings"
+    }
+
+private fun NavDestination?.analyticsScreenName(): String? =
+    when {
+        this == null -> null
+        hasRoute(Route.Home::class) -> "home"
+        hasRoute(Route.LatestFeed::class) -> "latest_feed"
+        hasRoute(Route.Favorite::class) -> "favorite"
+        hasRoute(Route.History::class) -> "history"
+        hasRoute(Route.Settings::class) -> "settings"
+        hasRoute(Route.Contact::class) -> "contact"
+        hasRoute(Route.Detail::class) -> "detail"
+        hasRoute(Route.BlogList::class) -> "blog_list"
+        hasRoute(Route.Blog::class) -> "blog"
+        else -> null
+    }

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/home/HomeScreen.kt
@@ -39,6 +39,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
+import org.ikseong.artech.analytics.AnalyticsEvents
+import org.ikseong.artech.analytics.AnalyticsTracker
+import org.ikseong.artech.data.model.Article
 import org.ikseong.artech.ui.component.ArticleCard
 import org.ikseong.artech.ui.component.HomeSectionHeader
 import org.ikseong.artech.ui.component.InterestTopicHubCard
@@ -46,6 +49,7 @@ import org.ikseong.artech.ui.component.RecommendedArticleCard
 import org.ikseong.artech.ui.component.ScrollToTopFab
 import org.ikseong.artech.util.PlatformBackHandler
 import org.ikseong.artech.util.rememberExitAppAction
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,6 +61,7 @@ fun HomeScreen(
     onLatestFeedClick: () -> Unit = {},
     onTopicClick: (String) -> Unit = {},
     viewModel: HomeViewModel = koinViewModel(),
+    analyticsTracker: AnalyticsTracker = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
@@ -178,7 +183,12 @@ fun HomeScreen(
                                     actionLabel = "새로고침",
                                     actionEnabled = !uiState.isRefreshingTodayPicks,
                                     actionLoading = uiState.isRefreshingTodayPicks,
-                                    onActionClick = viewModel::refreshRecommendations,
+                                    onActionClick = {
+                                        analyticsTracker.logEvent(
+                                            AnalyticsEvents.recommendationRefresh(source = "home"),
+                                        )
+                                        viewModel.refreshRecommendations()
+                                    },
                                 )
                             }
 
@@ -194,7 +204,10 @@ fun HomeScreen(
                                     ) { article ->
                                         RecommendedArticleCard(
                                             article = article,
-                                            onClick = { onArticleClick(article.id, article.link) },
+                                            onClick = {
+                                                analyticsTracker.logArticleOpen(article, source = "home_today_picks")
+                                                onArticleClick(article.id, article.link)
+                                            },
                                             isNew = uiState.lastVisitTime?.let { article.displayDate > it } ?: false,
                                         )
                                     }
@@ -228,10 +241,21 @@ fun HomeScreen(
                             ) { article ->
                                 ArticleCard(
                                     article = article,
-                                    onClick = { onArticleClick(article.id, article.link) },
+                                    onClick = {
+                                        analyticsTracker.logArticleOpen(article, source = "home_missed")
+                                        onArticleClick(article.id, article.link)
+                                    },
                                     modifier = Modifier.padding(horizontal = 16.dp),
                                     isNew = uiState.lastVisitTime?.let { article.displayDate > it } ?: false,
-                                    onBlogClick = onBlogClick,
+                                    onBlogClick = { blogSource ->
+                                        analyticsTracker.logEvent(
+                                            AnalyticsEvents.blogOpen(
+                                                source = "home_missed",
+                                                blogSource = blogSource,
+                                            ),
+                                        )
+                                        onBlogClick(blogSource)
+                                    },
                                 )
                             }
                         }
@@ -251,10 +275,21 @@ fun HomeScreen(
                             ) { article ->
                                 ArticleCard(
                                     article = article,
-                                    onClick = { onArticleClick(article.id, article.link) },
+                                    onClick = {
+                                        analyticsTracker.logArticleOpen(article, source = "home_latest_preview")
+                                        onArticleClick(article.id, article.link)
+                                    },
                                     modifier = Modifier.padding(horizontal = 16.dp),
                                     isNew = uiState.lastVisitTime?.let { article.displayDate > it } ?: false,
-                                    onBlogClick = onBlogClick,
+                                    onBlogClick = { blogSource ->
+                                        analyticsTracker.logEvent(
+                                            AnalyticsEvents.blogOpen(
+                                                source = "home_latest_preview",
+                                                blogSource = blogSource,
+                                            ),
+                                        )
+                                        onBlogClick(blogSource)
+                                    },
                                 )
                             }
                         }
@@ -289,6 +324,20 @@ private fun HomeUiState.homeListItemCount(): Int =
 
 private fun sectionItemCount(hasSection: Boolean, count: Int): Int =
     if (hasSection) count else 0
+
+private fun AnalyticsTracker.logArticleOpen(
+    article: Article,
+    source: String,
+) {
+    logEvent(
+        AnalyticsEvents.articleOpen(
+            articleId = article.id,
+            source = source,
+            category = article.category,
+            blogSource = article.blogSource,
+        ),
+    )
+}
 
 @Composable
 private fun LoadingState() {

--- a/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/latest/LatestFeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ikseong/artech/ui/screen/latest/LatestFeedScreen.kt
@@ -41,9 +41,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
+import org.ikseong.artech.analytics.AnalyticsEvents
+import org.ikseong.artech.analytics.AnalyticsTracker
+import org.ikseong.artech.data.model.Article
 import org.ikseong.artech.ui.component.ArticleCard
 import org.ikseong.artech.ui.component.CategoryFilterRow
 import org.ikseong.artech.ui.component.ScrollToTopFab
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,6 +57,7 @@ fun LatestFeedScreen(
     onBlogClick: (String) -> Unit,
     onBack: () -> Unit,
     viewModel: LatestFeedViewModel = koinViewModel(),
+    analyticsTracker: AnalyticsTracker = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
@@ -154,7 +159,15 @@ fun LatestFeedScreen(
                             ) {
                                 CategoryFilterRow(
                                     selectedCategory = uiState.selectedCategory,
-                                    onCategorySelected = viewModel::selectCategory,
+                                    onCategorySelected = { category ->
+                                        analyticsTracker.logEvent(
+                                            AnalyticsEvents.categorySelect(
+                                                source = "latest_feed",
+                                                category = category,
+                                            ),
+                                        )
+                                        viewModel.selectCategory(category)
+                                    },
                                     categories = uiState.categories,
                                 )
 
@@ -164,7 +177,15 @@ fun LatestFeedScreen(
                                 ) {
                                     FilterChip(
                                         selected = uiState.showUnreadOnly,
-                                        onClick = viewModel::toggleUnreadFilter,
+                                        onClick = {
+                                            analyticsTracker.logEvent(
+                                                AnalyticsEvents.unreadFilterToggle(
+                                                    source = "latest_feed",
+                                                    enabled = !uiState.showUnreadOnly,
+                                                ),
+                                            )
+                                            viewModel.toggleUnreadFilter()
+                                        },
                                         label = {
                                             Text(
                                                 "안 본 글만",
@@ -221,10 +242,24 @@ fun LatestFeedScreen(
                         ) { article ->
                             ArticleCard(
                                 article = article,
-                                onClick = { onArticleClick(article.id, article.link) },
+                                onClick = {
+                                    analyticsTracker.logArticleOpen(
+                                        article = article,
+                                        source = "latest_feed",
+                                    )
+                                    onArticleClick(article.id, article.link)
+                                },
                                 modifier = Modifier.padding(horizontal = 16.dp),
                                 isNew = uiState.lastVisitTime?.let { article.displayDate > it } ?: false,
-                                onBlogClick = onBlogClick,
+                                onBlogClick = { blogSource ->
+                                    analyticsTracker.logEvent(
+                                        AnalyticsEvents.blogOpen(
+                                            source = "latest_feed",
+                                            blogSource = blogSource,
+                                        ),
+                                    )
+                                    onBlogClick(blogSource)
+                                },
                             )
                         }
 
@@ -255,4 +290,18 @@ fun LatestFeedScreen(
             }
         }
     }
+}
+
+private fun AnalyticsTracker.logArticleOpen(
+    article: Article,
+    source: String,
+) {
+    logEvent(
+        AnalyticsEvents.articleOpen(
+            articleId = article.id,
+            source = source,
+            category = article.category,
+            blogSource = article.blogSource,
+        ),
+    )
 }

--- a/composeApp/src/commonTest/kotlin/org/ikseong/artech/analytics/AnalyticsEventsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ikseong/artech/analytics/AnalyticsEventsTest.kt
@@ -1,0 +1,48 @@
+package org.ikseong.artech.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class AnalyticsEventsTest {
+    @Test
+    fun articleOpenEventKeepsStableNameAndContext() {
+        val event = AnalyticsEvents.articleOpen(
+            articleId = 42,
+            source = "home_today_picks",
+            category = "android",
+            blogSource = "android-developers",
+        )
+
+        assertEquals("article_open", event.name)
+        assertEquals("42", event.parameters["article_id"])
+        assertEquals("home_today_picks", event.parameters["source"])
+        assertEquals("android", event.parameters["category"])
+        assertEquals("android-developers", event.parameters["blog_source"])
+    }
+
+    @Test
+    fun blankOptionalArticleContextIsOmitted() {
+        val event = AnalyticsEvents.articleOpen(
+            articleId = 7,
+            source = "latest_feed",
+            category = "",
+            blogSource = null,
+        )
+
+        assertFalse("category" in event.parameters)
+        assertFalse("blog_source" in event.parameters)
+    }
+
+    @Test
+    fun categorySelectionEventUsesStableParameterNames() {
+        val event = AnalyticsEvents.categorySelect(
+            source = "home_topic_hub",
+            category = "ios",
+        )
+
+        assertEquals("category_select", event.name)
+        assertEquals("home_topic_hub", event.parameters["source"])
+        assertEquals("ios", event.parameters["category"])
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/ikseong/artech/analytics/IosAnalyticsTracker.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/ikseong/artech/analytics/IosAnalyticsTracker.ios.kt
@@ -1,0 +1,28 @@
+package org.ikseong.artech.analytics
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class IosAnalyticsTracker : AnalyticsTracker {
+    override fun logEvent(event: AnalyticsEvent) {
+        IosAnalyticsBridge.logEvent(
+            name = event.name,
+            parametersJson = Json.encodeToString(event.parameters),
+        )
+    }
+}
+
+object IosAnalyticsBridge {
+    private var logger: ((name: String, parametersJson: String) -> Unit)? = null
+
+    fun setLogger(logger: (name: String, parametersJson: String) -> Unit) {
+        this.logger = logger
+    }
+
+    fun logEvent(
+        name: String,
+        parametersJson: String,
+    ) {
+        logger?.invoke(name, parametersJson)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/ikseong/artech/di/PlatformModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/ikseong/artech/di/PlatformModule.ios.kt
@@ -1,5 +1,7 @@
 package org.ikseong.artech.di
 
+import org.ikseong.artech.analytics.AnalyticsTracker
+import org.ikseong.artech.analytics.IosAnalyticsTracker
 import org.ikseong.artech.data.local.DataStoreFactory
 import org.ikseong.artech.data.local.DatabaseFactory
 import org.koin.core.module.Module
@@ -8,4 +10,5 @@ import org.koin.dsl.module
 actual val platformModule: Module = module {
     single { DatabaseFactory() }
     single { DataStoreFactory() }
+    single<AnalyticsTracker> { IosAnalyticsTracker() }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ coil = "3.2.0"
 buildkonfig = "0.15.2"
 datastore = "1.1.7"
 supabase = "3.3.0"
+firebase-bom = "34.7.0"
+google-services = "4.4.4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -54,6 +56,8 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastore" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -65,3 +69,4 @@ kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", vers
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "room" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,11 +1,17 @@
 import SwiftUI
 import ComposeApp
 import FirebaseCore
+import FirebaseAnalytics
+import Foundation
 
 @main
 struct iOSApp: App {
     init() {
         FirebaseApp.configure()
+        IosAnalyticsBridge.shared.setLogger { name, parametersJson in
+            let parameters = Self.decodeAnalyticsParameters(parametersJson)
+            Analytics.logEvent(name, parameters: parameters)
+        }
         KoinHelperKt.doInitKoin()
     }
 
@@ -13,5 +19,14 @@ struct iOSApp: App {
         WindowGroup {
             ContentView()
         }
+    }
+
+    private static func decodeAnalyticsParameters(_ parametersJson: String) -> [String: Any] {
+        guard let data = parametersJson.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let parameters = object as? [String: Any] else {
+            return [:]
+        }
+        return parameters
     }
 }


### PR DESCRIPTION
## Summary
- Add shared analytics event definitions and Android/iOS Firebase Analytics bridges
- Log screen, tab, category, article, blog, recommendation refresh, and unread filter events
- Add tests for stable analytics event names and parameters

## Verification
- Emulator: confirmed app launch, home screen, tab navigation, Firebase app events, and 204 upload response
- ANDROID_HOME=/Users/ikseong/Library/Android/sdk ./gradlew :composeApp:allTests :composeApp:compileDebugKotlinAndroid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 상호작용을 추적하는 분석 기능 추가
  * 화면 조회, 기사 열기, 카테고리 선택, 블로그 열기, 피드 새로고침 등 주요 이벤트 로깅 지원
  * Android 및 iOS 플랫폼에서 Firebase Analytics 통합
  * 빌드 구성에 따른 분석 기능 선택적 활성화

* **테스트**
  * 분석 이벤트 생성 및 파라미터 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->